### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -42,7 +42,7 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v4.0.1
         with:
           node-version: "latest"
           cache: ${{ steps.detect-package-manager.outputs.manager }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.1](https://github.com/actions/setup-node/releases/tag/v4.0.1)** on 2023-12-18T11:05:34Z
