### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -42,12 +42,12 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: "latest"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Restore cache
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.1.2
         with:
           path: |
             .next/cache

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.CWB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)** on 2024-10-24T13:51:16Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.2](https://github.com/actions/cache/releases/tag/v4.1.2)** on 2024-10-22T13:08:44Z
