### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4.1.0
         name: Install pnpm
         with:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: latest
           cache: "pnpm"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v4.1.0](https://github.com/pnpm/action-setup/releases/tag/v4.1.0)** on 2025-02-06T21:33:00Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.3.0](https://github.com/actions/setup-node/releases/tag/v4.3.0)** on 2025-03-17T02:44:28Z
